### PR TITLE
AML-3143 Fix Unit Tests On Build Server

### DIFF
--- a/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/AuthorizationHandlerTests.cs
+++ b/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/AuthorizationHandlerTests.cs
@@ -16,31 +16,31 @@ namespace SFA.DAS.Authorization.EmployerFeatures.UnitTests
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreNotAvailable_ThenShouldReturnValidAuthorizationResult()
         {
-            return RunAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            return TestAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenAndedOptionsAreAvailable_ThenShouldThrowNotImplementedException()
         {
-            return RunAsync(f => f.SetAndedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
+            return TestExceptionAsync(f => f.SetAndedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenOredOptionIsAvailable_ThenShouldThrowNotImplementedException()
         {
-            return RunAsync(f => f.SetOredOption(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
+            return TestExceptionAsync(f => f.SetOredOption(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsIsMissingAccountId_ThenShouldThrowKeyNotFoundException()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextMissingAccountId(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextMissingAccountId(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsMissingUserEmail_ThenShouldThrowKeyNotFoundException()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextMissingUserEmail(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextMissingUserEmail(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
         }
 
         [TestCase(1, null)]
@@ -49,48 +49,48 @@ namespace SFA.DAS.Authorization.EmployerFeatures.UnitTests
         [TestCase(null, null)]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableButContainsInvalidValues_ThenShouldThrowInvalidOperationException(long? accountId, string userEmail)
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues(accountId, userEmail), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<InvalidOperationException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextValues(accountId, userEmail), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<InvalidOperationException>());
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsEnabled_ThenShouldReturnAuthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsEnabledAndAccountIdIsWhitelisted_ThenShouldReturnAuthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsEnabledAndAccountIdIsWhitelistedAndUserEmailIsWhitelisted_ThenShouldReturnAuthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true, true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true, true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsNotEnabled_ThenShouldReturnUnauthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => !r2.IsAuthorized && r2.Errors.Count() == 1 && r2.HasError<EmployerFeatureNotEnabled>()));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsEnabledAndAccountIdIsNotWhitelisted_ThenShouldReturnUnauthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => !r2.IsAuthorized && r2.Errors.Count() == 1 && r2.HasError<EmployerFeatureUserNotWhitelisted>()));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableAndFeatureIsEnabledAndAccountIdIsWhitelistedAndUserEmailIsNotWhitelisted_ThenShouldReturnUnauthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true, false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetFeatureToggle(true, true, false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => !r2.IsAuthorized && r2.Errors.Count() == 1 && r2.HasError<EmployerFeatureUserNotWhitelisted>()));
         }
     }

--- a/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/FeatureTogglesServiceTests.cs
+++ b/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/FeatureTogglesServiceTests.cs
@@ -13,13 +13,13 @@ namespace SFA.DAS.Authorization.EmployerFeatures.UnitTests
         [Test]
         public void GetFeatureToggle_WhenFeatureToggleExistsForFeature_ThenShouldReturnFeatureToggle()
         {
-            Run(f => f.SetFeatureToggle(), f => f.GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.BeSameAs(f.FeatureToggle));
+            Test(f => f.SetFeatureToggle(), f => f.GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.BeSameAs(f.FeatureToggle));
         }
         
         [Test]
         public void GetFeatureToggle_WhenFeatureToggleDoesNotExistForFeature_ThenShouldReturnDisabledFeatureToggle()
         {
-            Run(f => f.GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.Match<FeatureToggle>(t => t.Feature == f.Feature && t.IsEnabled == false));
+            Test(f => f.GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.Match<FeatureToggle>(t => t.Feature == f.Feature && t.IsEnabled == false));
         }
     }
 

--- a/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/SFA.DAS.Authorization.EmployerFeatures.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/SFA.DAS.Authorization.EmployerFeatures.UnitTests.csproj
@@ -9,10 +9,10 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/SFA.DAS.Authorization.EmployerFeatures.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.EmployerFeatures.UnitTests/SFA.DAS.Authorization.EmployerFeatures.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/AuthorizationHandlerTests.cs
+++ b/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/AuthorizationHandlerTests.cs
@@ -13,19 +13,19 @@ namespace SFA.DAS.Authorization.EmployerRoles.UnitTests
         [Test]
         public Task GetAuthorizationResult_WhenGettingAuthorizationResultAndOptionsAreNotAvailable_ThenShouldReturnValidAuthorizationResult()
         {
-            return RunAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            return TestAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test, Ignore("until handler written")]
         public Task GetAuthorizationResult_WhenGettingAuthorizationResultAndNonEmployerRolesOptionsAreAvailable_ThenShouldReturnValidAuthorizationResult()
         {
-            return RunAsync(f => f.SetNonEmployerRolesOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            return TestAsync(f => f.SetNonEmployerRolesOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenGettingAuthorizationResultAndEmployerRolesOptionsAreAvailableAndEmployerRoleContextIsNotAvailable_ThenShouldThrowAuthorizationContextKeyNotFoundException()
         {
-            return RunAsync(f => f.SetEmployerRolesOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
+            return TestExceptionAsync(f => f.SetEmployerRolesOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
         }
     }
 

--- a/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/SFA.DAS.Authorization.EmployerRoles.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/SFA.DAS.Authorization.EmployerRoles.UnitTests.csproj
@@ -9,10 +9,10 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/SFA.DAS.Authorization.EmployerRoles.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.EmployerRoles.UnitTests/SFA.DAS.Authorization.EmployerRoles.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/AuthorizationFilterTests.cs
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/AuthorizationFilterTests.cs
@@ -17,49 +17,49 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionIsDecoratedWithDasAuthorizeAttributeAndActionOptionsAreAuthorized_ThenShouldNotSetResult()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetAuthorizedActionOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
+            Test(f => f.SetActionDasAuthorizeAttribute().SetAuthorizedActionOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndControllerIsDecoratedWithDasAuthorizeAttributeAndControllerOptionsAreAuthorized_ThenShouldNotSetResult()
         {
-            Run(f => f.SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
+            Test(f => f.SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreDecoratedWithDasAuthorizeAttributeAndActionAndControllerOptionsAreAuthorized_ThenShouldNotSetResult()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute().SetAuthorizedActionOptions().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute().SetAuthorizedActionOptions().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionIsDecoratedWithDasAuthorizeAttributeAndActionOptionsAreNotAuthorized_ThenShouldSetResult()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
+            Test(f => f.SetActionDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndControllerIsDecoratedWithDasAuthorizeAttributeAndControllerOptionsAreNotAuthorized_ThenShouldSetResult()
         {
-            Run(f => f.SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
+            Test(f => f.SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreDecoratedWithDasAuthorizeAttributeAndActionAndControllerOptionsAreNotAuthorized_ThenShouldSetResult()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreNotDecoratedWithDasAuthorizeAttribute_ThenShouldNotSetResult()
         {
-            Run(f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
+            Test(f => f.OnActionExecuting(), f => f.ActionExecutingContext.Result.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingMoreThanOnce_ThenShouldNotGetDasAuthorizeAttributeMoreThanOnce()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecutingMoreThanOnce(), f =>
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecutingMoreThanOnce(), f =>
             {
                 f.ActionDescriptor.Verify(d => d.GetCustomAttributes(typeof(DasAuthorizeAttribute), true), Times.Once);
                 f.ActionDescriptor.Verify(d => d.ControllerDescriptor.GetCustomAttributes(typeof(DasAuthorizeAttribute), true), Times.Once);

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/AuthorizationModelBinderTests.cs
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/AuthorizationModelBinderTests.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void BindModel_WhenBindingAnAuthorizationContextModelAndAPropertyNameExistsInTheAuthorizationContext_ThenShouldSetThePropertyValue()
         {
-            Run(f => f.SetAuthorizationContext(), f => f.BindModel(), (f, r) =>
+            Test(f => f.SetAuthorizationContext(), f => f.BindModel(), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.UserRef.Should().Be(f.UserRef);
@@ -28,7 +28,7 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void BindModel_WhenBindingAnAuthorizationContextModelAndAPropertyNameDoesNotExistInTheAuthorizationContext_ThenShouldNotSetThePropertyValue()
         {
-            Run(f => f.BindModel(), (f, r) =>
+            Test(f => f.BindModel(), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.UserRef.Should().BeNull();

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/DasAuthorizeAttributeTests.cs
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/DasAuthorizeAttributeTests.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void Constructor_WhenConstructingADasAuthorizeAttributeWithOptions_ThenShouldConstructADasAuthorizeAttribute()
         {
-            Run(f => new DasAuthorizeAttribute(f.Options), (f, r) =>
+            Test(f => new DasAuthorizeAttribute(f.Options), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.Options.Should().BeSameAs(f.Options);
@@ -23,7 +23,7 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void Constructor_WhenConstructingADasAuthorizeAttributeWithNullOptions_ThenShouldThrowAnException()
         {
-            Run(f => new DasAuthorizeAttribute(null), (f, r) => r.Should().Throw<ArgumentNullException>());
+            TestException(f => new DasAuthorizeAttribute(null), (f, r) => r.Should().Throw<ArgumentNullException>());
         }
     }
 

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/HtmlHelperExtensionsTests.cs
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/HtmlHelperExtensionsTests.cs
@@ -14,19 +14,19 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void IsAuthorized_WhenOperationIsAuthorized_ThenShouldReturnTrue()
         {
-            Run(f => f.SetAuthorized(), f => f.IsAuthorized(), (f, r) => r.Should().BeTrue());
+            Test(f => f.SetAuthorized(), f => f.IsAuthorized(), (f, r) => r.Should().BeTrue());
         }
 
         [Test]
         public void IsAuthorized_WhenOperationIsUnauthorized_ThenShouldReturnFalse()
         {
-            Run(f => f.SetUnauthorized(), f => f.IsAuthorized(), (f, r) => r.Should().BeFalse());
+            Test(f => f.SetUnauthorized(), f => f.IsAuthorized(), (f, r) => r.Should().BeFalse());
         }
 
         [Test]
         public void GetAuthorizationResult_WhenGettingAuthorizationResult_ThenShouldReturnAuthorizationResult()
         {
-            Run(f => f.SetAuthorizationResult(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.BeSameAs(f.AuthorizationResult));
+            Test(f => f.SetAuthorizationResult(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.BeSameAs(f.AuthorizationResult));
         }
     }
 

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
@@ -25,10 +25,10 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/SFA.DAS.Authorization.Mvc.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
+        <TargetFramework>net462</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.Mvc.UnitTests/UnauthorizedAccessExceptionFilterTests.cs
+++ b/src/SFA.DAS.Authorization.Mvc.UnitTests/UnauthorizedAccessExceptionFilterTests.cs
@@ -15,25 +15,25 @@ namespace SFA.DAS.Authorization.Mvc.UnitTests
         [Test]
         public void OnException_WhenAnUnauthorizedAccessExceptionIsThrown_ThenShouldSetResult()
         {
-            Run(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ExceptionContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
+            Test(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ExceptionContext.Result.Should().NotBeNull().And.Match<HttpStatusCodeResult>(r => r.StatusCode == (int)HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnException_WhenAnUnauthorizedAccessExceptionIsThrown_ThenShouldSetExceptionHandled()
         {
-            Run(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ExceptionContext.ExceptionHandled.Should().BeTrue());
+            Test(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ExceptionContext.ExceptionHandled.Should().BeTrue());
         }
 
         [Test]
         public void OnException_WhenAnExceptionIsThrown_ThenShouldNotSetResult()
         {
-            Run(f => f.SetException(), f => f.OnException(), f => f.ExceptionContext.Result.Should().NotBeNull().And.BeOfType<EmptyResult>());
+            Test(f => f.SetException(), f => f.OnException(), f => f.ExceptionContext.Result.Should().NotBeNull().And.BeOfType<EmptyResult>());
         }
 
         [Test]
         public void OnException_WhenAnExceptionIsThrown_ThenShouldNotSetExceptionHandled()
         {
-            Run(f => f.SetException(), f => f.OnException(), f => f.ExceptionContext.ExceptionHandled.Should().BeFalse());
+            Test(f => f.SetException(), f => f.OnException(), f => f.ExceptionContext.ExceptionHandled.Should().BeFalse());
         }
     }
 

--- a/src/SFA.DAS.Authorization.Mvc/ActionDescriptorExtensions.cs
+++ b/src/SFA.DAS.Authorization.Mvc/ActionDescriptorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
@@ -25,4 +24,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/AuthorizationFilter.cs
+++ b/src/SFA.DAS.Authorization.Mvc/AuthorizationFilter.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System;
+﻿using System;
 using System.Linq;
 using System.Net;
 using System.Web.Mvc;
@@ -32,4 +31,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/AuthorizationModelBinder.cs
+++ b/src/SFA.DAS.Authorization.Mvc/AuthorizationModelBinder.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Web.Mvc;
@@ -37,4 +36,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/DasAuthorizeAttribute.cs
+++ b/src/SFA.DAS.Authorization.Mvc/DasAuthorizeAttribute.cs
@@ -1,4 +1,3 @@
-#if NET462
 using System;
 using System.Web.Mvc;
 
@@ -15,4 +14,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/GlobalFilterCollectionExtensions.cs
+++ b/src/SFA.DAS.Authorization.Mvc/GlobalFilterCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace SFA.DAS.Authorization.Mvc
 {
@@ -16,4 +15,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/HtmlHelperExtensions.cs
+++ b/src/SFA.DAS.Authorization.Mvc/HtmlHelperExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace SFA.DAS.Authorization.Mvc
 {
@@ -22,4 +21,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/ModelBinderDictionaryExtensions.cs
+++ b/src/SFA.DAS.Authorization.Mvc/ModelBinderDictionaryExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace SFA.DAS.Authorization.Mvc
 {
@@ -11,4 +10,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.Mvc/SFA.DAS.Authorization.Mvc.csproj
+++ b/src/SFA.DAS.Authorization.Mvc/SFA.DAS.Authorization.Mvc.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>      
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+        <TargetFrameworks>net462</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         
         <Authors>DAS</Authors>

--- a/src/SFA.DAS.Authorization.Mvc/SFA.DAS.Authorization.Mvc.csproj
+++ b/src/SFA.DAS.Authorization.Mvc/SFA.DAS.Authorization.Mvc.csproj
@@ -14,27 +14,12 @@
         <EmbedUntrackedSources>false</EmbedUntrackedSources>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
-    
-    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-        <DefineConstants>NETCOREAPP2_0</DefineConstants>
-    </PropertyGroup>
-    
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
-        <DefineConstants>NET462</DefineConstants>
-    </PropertyGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.6" />
-    </ItemGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.6" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\SFA.DAS.Authorization\SFA.DAS.Authorization.csproj" />
     </ItemGroup>

--- a/src/SFA.DAS.Authorization.Mvc/UnauthorizedAccessExceptionFilter.cs
+++ b/src/SFA.DAS.Authorization.Mvc/UnauthorizedAccessExceptionFilter.cs
@@ -1,5 +1,4 @@
-﻿#if NET462
-using System;
+﻿using System;
 using System.Net;
 using System.Web.Mvc;
 
@@ -17,4 +16,3 @@ namespace SFA.DAS.Authorization.Mvc
         }
     }
 }
-#endif

--- a/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/AuthorizationHandlerTests.cs
+++ b/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/AuthorizationHandlerTests.cs
@@ -20,31 +20,31 @@ namespace SFA.DAS.Authorization.ProviderPermissions.UnitTests
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreNotAvailable_ThenShouldReturnValidAuthorizationResult()
         {
-            return RunAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            return TestAsync(f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenAndedOptionsAreAvailable_ThenShouldThrowNotImplementedException()
         {
-            return RunAsync(f => f.SetAndedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
+            return TestExceptionAsync(f => f.SetAndedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOredOptionIsAvailable_ThenShouldThrowNotImplementedException()
         {
-            return RunAsync(f => f.SetOredOption(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
+            return TestExceptionAsync(f => f.SetOredOption(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<NotImplementedException>());
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsMissingAccountLegalEntityId_ThenShouldThrowKeyNotFoundException()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextMissingAccountLegalEntityId(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextMissingAccountLegalEntityId(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
         }
 
         [Test]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsMissingUkprn_ThenShouldThrowKeyNotFoundException()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextMissingUkprn(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextMissingUkprn(), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<KeyNotFoundException>());
         }
         
         [TestCase(1L, null)]
@@ -52,20 +52,20 @@ namespace SFA.DAS.Authorization.ProviderPermissions.UnitTests
         [TestCase(null, null)]
         public Task GetAuthorizationResult_WhenOptionsAreAvailableAndAuthorizationContextIsAvailableButContainsInvalidValues_ThenShouldThrowInvalidOperationException(long? accountLegalEntityId, long? ukprn)
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues(accountLegalEntityId, ukprn), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<InvalidOperationException>());
+            return TestExceptionAsync(f => f.SetOption().SetAuthorizationContextValues(accountLegalEntityId, ukprn), f => f.GetAuthorizationResult(), (f, r) => r.Should().Throw<InvalidOperationException>());
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenProviderPermissionsOptionsAreAvailableAndProviderPermissionsContextIsAvailableAndCreateCohortPermissionIsGranted_ThenShouldReturnAuthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetPermissionGranted(true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetPermissionGranted(true), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
         
         [Test]
         public Task GetAuthorizationResult_WhenProviderPermissionsOptionsAreAvailableAndProviderPermissionsContextIsAvailableAndCreateCohortPermissionIsNotGranted_ThenShouldReturnUnauthorizedAuthorizationResult()
         {
-            return RunAsync(f => f.SetOption().SetAuthorizationContextValues().SetPermissionGranted(false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
+            return TestAsync(f => f.SetOption().SetAuthorizationContextValues().SetPermissionGranted(false), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull()
                 .And.Match<AuthorizationResult>(r2 => !r2.IsAuthorized && r2.Errors.Count() == 1 && r2.HasError<ProviderPermissionNotGranted>()));
         }
     }

--- a/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/SFA.DAS.Authorization.ProviderPermissions.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/SFA.DAS.Authorization.ProviderPermissions.UnitTests.csproj
@@ -9,10 +9,10 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/SFA.DAS.Authorization.ProviderPermissions.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.ProviderPermissions.UnitTests/SFA.DAS.Authorization.ProviderPermissions.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextTests.cs
+++ b/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextTests.cs
@@ -12,19 +12,19 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void Get_WhenKeyExists_ThenShouldReturnData()
         {
-            Run(f => f.SetData(), f => f.GetData(), (f, d) => d.Should().Be(f.Data));
+            Test(f => f.SetData(), f => f.GetData(), (f, d) => d.Should().Be(f.Data));
         }
 
         [Test]
         public void Get_WhenKeyDoesNotExist_ThenShouldThrowException()
         {
-            Run(f => f.GetData(), (f, r) => r.Should().Throw<KeyNotFoundException>().WithMessage($"The key '{f.Key}' was not present in the authorization context"));
+            TestException(f => f.GetData(), (f, r) => r.Should().Throw<KeyNotFoundException>().WithMessage($"The key '{f.Key}' was not present in the authorization context"));
         }
 
         [Test]
         public void TryGet_WhenKeyExists_ThenShouldReturnTrueAndValueShouldNotBeNull()
         {
-            Run(f => f.SetData(), f => f.TryGetData(), (f, r) =>
+            Test(f => f.SetData(), f => f.TryGetData(), (f, r) =>
             {
                 r.Should().BeTrue();
                 f.Value.Should().NotBeNull().And.Be(f.Data);
@@ -34,7 +34,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void TryGet_WhenKeyDoesNotExist_ThenShouldReturnFalseAndValueShouldBeNull()
         {
-            Run(f => f.TryGetData(), (f, r) =>
+            Test(f => f.TryGetData(), (f, r) =>
             {
                 r.Should().BeFalse();
                 f.Value.Should().BeNull();

--- a/src/SFA.DAS.Authorization.UnitTests/AuthorizationResultTests.cs
+++ b/src/SFA.DAS.Authorization.UnitTests/AuthorizationResultTests.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void Constructor_WhenConstructingAnAuthorizationResult_ThenShouldConstructAValidAuthorizationResult()
         {
-            Run(f => new AuthorizationResult(), (f, r) =>
+            Test(f => new AuthorizationResult(), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeTrue();
@@ -25,7 +25,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void Constructor_WhenConstructingAnAuthorizationResultWithAnError_ThenShouldConstructAnInvalidAuthorizationResult()
         {
-            Run(f => new AuthorizationResult(f.EmployerRoleNotAuthorized), (f, r) =>
+            Test(f => new AuthorizationResult(f.EmployerRoleNotAuthorized), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();
@@ -36,7 +36,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void Constructor_WhenConstructingAnAuthorizationResultWithErrors_ThenShouldConstructAnInvalidAuthorizationResult()
         {
-            Run(f => new AuthorizationResult(f.Errors), (f, r) =>
+            Test(f => new AuthorizationResult(f.Errors), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();
@@ -47,7 +47,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void AddError_WhenAddingAnError_ThenShouldInvalidateAuthorizationResult()
         {
-            Run(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized), (f, r) =>
+            Test(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();
@@ -58,7 +58,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void AddError_WhenAddingAErrors_ThenShouldInvalidateAuthorizationResult()
         {
-            Run(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).AddError(f.ProviderPermissionNotGranted), (f, r) =>
+            Test(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).AddError(f.ProviderPermissionNotGranted), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();
@@ -69,13 +69,13 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void HasError_WhenAnErrorOfTypeExists_ThenShouldReturnTrue()
         {
-            Run(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).HasError<EmployerRoleNotAuthorized>(), (f, r) => r.Should().BeTrue());
+            Test(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).HasError<EmployerRoleNotAuthorized>(), (f, r) => r.Should().BeTrue());
         }
 
         [Test]
         public void HasError_WhenAnErrorOfTypeDoesNotExist_ThenShouldReturnFalse()
         {
-            Run(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).HasError<ProviderPermissionNotGranted>(), (f, r) => r.Should().BeFalse());
+            Test(f => new AuthorizationResult().AddError(f.EmployerRoleNotAuthorized).HasError<ProviderPermissionNotGranted>(), (f, r) => r.Should().BeFalse());
         }
     }
 

--- a/src/SFA.DAS.Authorization.UnitTests/AuthorizationServiceTests.cs
+++ b/src/SFA.DAS.Authorization.UnitTests/AuthorizationServiceTests.cs
@@ -18,61 +18,61 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void Authorize_WhenOperationIsAuthorized_ThenShouldNotThrowException()
         {
-            Run(f => f.SetAuthorizedOptions(), f => f.Authorize(), f => {});
+            Test(f => f.SetAuthorizedOptions(), f => f.Authorize(), f => {});
         }
         
         [Test]
         public void Authorize_WhenOperationIsUnauthorized_ThenShouldThrowException()
         {
-            Run(f => f.SetUnauthorizedOptions(), f => f.Authorize(), (f, r) => r.Should().Throw<UnauthorizedAccessException>());
+            TestException(f => f.SetUnauthorizedOptions(), f => f.Authorize(), (f, r) => r.Should().Throw<UnauthorizedAccessException>());
         }
         
         [Test]
         public Task AuthorizeAsync_WhenOperationIsAuthorized_ThenShouldNotThrowException()
         {
-            return RunAsync(f => f.SetAuthorizedOptions(), f => f.AuthorizeAsync(), f => {});
+            return TestAsync(f => f.SetAuthorizedOptions(), f => f.AuthorizeAsync(), f => {});
         }
         
         [Test]
         public Task AuthorizeAsync_WhenOperationIsUnauthorized_ThenShouldThrowException()
         {
-            return RunAsync(f => f.SetUnauthorizedOptions(), f => f.AuthorizeAsync(), (f, r) => r.Should().Throw<UnauthorizedAccessException>());
+            return TestExceptionAsync(f => f.SetUnauthorizedOptions(), f => f.AuthorizeAsync(), (f, r) => r.Should().Throw<UnauthorizedAccessException>());
         }
         
         [Test]
         public Task IsAuthorizedAsync_WhenOperationIsAuthorized_ThenShouldReturnTrue()
         {
-            return RunAsync(f => f.SetAuthorizedOptions(), f => f.IsAuthorizedAsync(), (f, r) => r.Should().BeTrue());
+            return TestAsync(f => f.SetAuthorizedOptions(), f => f.IsAuthorizedAsync(), (f, r) => r.Should().BeTrue());
         }
 
         [Test]
         public Task IsAuthorizedAsync_WhenOperationIsUnauthorized_ThenShouldReturnTrue()
         {
-            return RunAsync(f => f.SetUnauthorizedOptions(), f => f.IsAuthorizedAsync(), (f, r) => r.Should().BeFalse());
+            return TestAsync(f => f.SetUnauthorizedOptions(), f => f.IsAuthorizedAsync(), (f, r) => r.Should().BeFalse());
         }
 
         [Test]
         public void IsAuthorized_WhenOperationIsAuthorized_ThenShouldReturnTrue()
         {
-            Run(f => f.SetAuthorizedOptions(), f => f.IsAuthorized(), (f, r) => r.Should().BeTrue());
+            Test(f => f.SetAuthorizedOptions(), f => f.IsAuthorized(), (f, r) => r.Should().BeTrue());
         }
 
         [Test]
         public void IsAuthorized_WhenOperationIsUnauthorized_ThenShouldReturnTrue()
         {
-            Run(f => f.SetUnauthorizedOptions(), f => f.IsAuthorized(), (f, r) => r.Should().BeFalse());
+            Test(f => f.SetUnauthorizedOptions(), f => f.IsAuthorized(), (f, r) => r.Should().BeFalse());
         }
 
         [Test]
         public Task GetAuthorizationResultAsync_WhenOperationIsAuthorized_ThenShouldReturnValidAuthorizationResult()
         {
-            return RunAsync(f => f.SetAuthorizedOptions(), f => f.GetAuthorizationResultAsync(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            return TestAsync(f => f.SetAuthorizedOptions(), f => f.GetAuthorizationResultAsync(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public Task GetAuthorizationResultAsync_WhenOperationIsUnauthorized_ThenShouldReturnInvalidAuthorizationResult()
         {
-            return RunAsync(f => f.SetUnauthorizedOptions(), f => f.GetAuthorizationResultAsync(), (f, r) =>
+            return TestAsync(f => f.SetUnauthorizedOptions(), f => f.GetAuthorizationResultAsync(), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();
@@ -83,13 +83,13 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void GetAuthorizationResult_WhenOperationIsAuthorized_ThenShouldReturnValidAuthorizationResult()
         {
-            Run(f => f.SetAuthorizedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
+            Test(f => f.SetAuthorizedOptions(), f => f.GetAuthorizationResult(), (f, r) => r.Should().NotBeNull().And.Match<AuthorizationResult>(r2 => r2.IsAuthorized));
         }
 
         [Test]
         public void GetAuthorizationResult_WhenOperationIsUnauthorized_ThenShouldReturnInvalidAuthorizationResult()
         {
-            Run(f => f.SetUnauthorizedOptions(), f => f.GetAuthorizationResult(), (f, r) =>
+            Test(f => f.SetUnauthorizedOptions(), f => f.GetAuthorizationResult(), (f, r) =>
             {
                 r.Should().NotBeNull();
                 r.IsAuthorized.Should().BeFalse();

--- a/src/SFA.DAS.Authorization.UnitTests/SFA.DAS.Authorization.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.UnitTests/SFA.DAS.Authorization.UnitTests.csproj
@@ -9,10 +9,10 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.UnitTests/SFA.DAS.Authorization.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.UnitTests/SFA.DAS.Authorization.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     

--- a/src/SFA.DAS.Authorization.WebApi.UnitTests/AuthorizationFilterTests.cs
+++ b/src/SFA.DAS.Authorization.WebApi.UnitTests/AuthorizationFilterTests.cs
@@ -21,49 +21,49 @@ namespace SFA.DAS.Authorization.WebApi.UnitTests
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionIsDecoratedWithDasAuthorizeAttributeAndActionOptionsAreAuthorized_ThenShouldNotSetResponse()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetAuthorizedActionOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
+            Test(f => f.SetActionDasAuthorizeAttribute().SetAuthorizedActionOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndControllerIsDecoratedWithDasAuthorizeAttributeAndControllerOptionsAreAuthorized_ThenShouldNotSetResponse()
         {
-            Run(f => f.SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
+            Test(f => f.SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreDecoratedWithDasAuthorizeAttributeAndActionAndControllerOptionsAreAuthorized_ThenShouldNotSetResponse()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute().SetAuthorizedControllerOptions(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionIsDecoratedWithDasAuthorizeAttributeAndActionOptionsAreNotAuthorized_ThenShouldSetResponse()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
+            Test(f => f.SetActionDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndControllerIsDecoratedWithDasAuthorizeAttributeAndControllerOptionsAreNotAuthorized_ThenShouldSetResponse()
         {
-            Run(f => f.SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
+            Test(f => f.SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreDecoratedWithDasAuthorizeAttributeAndTheOperationsAreNotAuthorized_ThenShouldSetResponse()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingAndActionAndControllerAreNotDecoratedWithDasAuthorizeAttribute_ThenShouldNotSetResponse()
         {
-            Run(f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
+            Test(f => f.OnActionExecuting(), f => f.ActionContext.Response.Should().BeNull());
         }
 
         [Test]
         public void OnActionExecuting_WhenActionIsExecutingMoreThanOnce_ThenShouldNotGetTheDasAuthorizeAttributeMoreThanOnce()
         {
-            Run(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecutingMoreThanOnce(), f =>
+            Test(f => f.SetActionDasAuthorizeAttribute().SetControllerDasAuthorizeAttribute(), f => f.OnActionExecutingMoreThanOnce(), f =>
             {
                 f.ActionDescriptor.Verify(d => d.GetCustomAttributes<DasAuthorizeAttribute>(true), Times.Once);
                 f.ControllerDescriptor.Verify(d => d.GetCustomAttributes<DasAuthorizeAttribute>(true), Times.Once);

--- a/src/SFA.DAS.Authorization.WebApi.UnitTests/AuthorizationModelBinderTests.cs
+++ b/src/SFA.DAS.Authorization.WebApi.UnitTests/AuthorizationModelBinderTests.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.Authorization.WebApi.UnitTests
         [Test]
         public void BindModel_WhenBindingAnAuthorizationContextModelAndAPropertyNameExistsInTheAuthorizationContext_ThenShouldSetThePropertyValue()
         {
-            Run(f => f.SetAuthorizationContext(), f => f.BindModel(), (f, r) =>
+            Test(f => f.SetAuthorizationContext(), f => f.BindModel(), (f, r) =>
             {
                 r.Should().BeTrue();
                 f.BindingContext.Model.Should().Be(f.UserRef);
@@ -34,7 +34,7 @@ namespace SFA.DAS.Authorization.WebApi.UnitTests
         [Test]
         public void BindModel_WhenBindingAnAuthorizationContextModelAndAPropertyNameDoesNotExistInTheAuthorizationContext_ThenShouldNotSetThePropertyValue()
         {
-            Run(f => f.BindModel(), (f, r) =>
+            Test(f => f.BindModel(), (f, r) =>
             {
                 r.Should().BeFalse();
                 f.BindingContext.Model.Should().BeNull();

--- a/src/SFA.DAS.Authorization.WebApi.UnitTests/SFA.DAS.Authorization.WebApi.UnitTests.csproj
+++ b/src/SFA.DAS.Authorization.WebApi.UnitTests/SFA.DAS.Authorization.WebApi.UnitTests.csproj
@@ -10,10 +10,10 @@
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.0" />
+        <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-        <PackageReference Include="SFA.DAS.Testing" Version="2.0.19" />
+        <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SFA.DAS.Authorization.WebApi.UnitTests/UnauthorizedAccessExceptionFilterTests.cs
+++ b/src/SFA.DAS.Authorization.WebApi.UnitTests/UnauthorizedAccessExceptionFilterTests.cs
@@ -18,13 +18,13 @@ namespace SFA.DAS.Authorization.WebApi.UnitTests
         [Test]
         public void OnException_WhenAnUnauthorizedAccessExceptionIsThrown_ThenShouldSetResponse()
         {
-            Run(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ActionExecutedContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
+            Test(f => f.SetUnauthorizedAccessException(), f => f.OnException(), f => f.ActionExecutedContext.Response.Should().NotBeNull().And.Match<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Forbidden));
         }
 
         [Test]
         public void OnException_WhenAnExceptionIsThrown_ThenShouldNotSetResponse()
         {
-            Run(f => f.SetException(), f => f.OnException(), f => f.ActionExecutedContext.Response.Should().BeNull());
+            Test(f => f.SetException(), f => f.OnException(), f => f.ActionExecutedContext.Response.Should().BeNull());
         }
     }
 


### PR DESCRIPTION
Late breaking news: the build definition has been changed to use dotnet test, and now the tests are run for all target frameworks on the build server.

Tests are only run (successfully) on the build server using the net462 framework.
Testing .netstandard libs using a .netcore unit test is not currently supported on the command line, see...
https://github.com/nunit/docs/wiki/.NET-Core-and-.NET-Standard
The tests *are* run for both .net and .netcore within rider, but Visual Studio (including 2019 preview) doesn't yet support running both.
This PR also updates to the latest SFA.DAS.Testing package.