### PR TITLE
Authorization context cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In addition to the `SFA.DAS.Authorization` package one or more of the following 
 ### MVC Core
 
 ```c#
+services.AddAuthorization<AuthorizationContextProvider>();
 services.AddEmployerFeaturesAuthorization();
 services.AddMvc(o => o.AddAuthorization());
 app.UseUnauthorizedAccessExceptionHandler();
@@ -46,6 +47,7 @@ config.Filters.AddUnauthorizedAccessExceptionFilter();
 If you're not using .NET Core then the authorization packages also include StructureMap registries for wiring up their components:
 
 ```c#
+c.AddRegistry<AuthorizationRegistry>();
 c.AddRegistry<EmployerFeaturesAuthorizationRegistry>();
 c.AddRegistry<EmployerUserRolesAuthorizationRegistry>();
 c.AddRegistry<ProviderPermissionsAuthorizationRegistry>();

--- a/src/SFA.DAS.Authorization.EmployerFeatures/EmployerFeaturesAuthorizationRegistry.cs
+++ b/src/SFA.DAS.Authorization.EmployerFeatures/EmployerFeaturesAuthorizationRegistry.cs
@@ -6,7 +6,6 @@ namespace SFA.DAS.Authorization.EmployerFeatures
     {
         public EmployerFeaturesAuthorizationRegistry()
         {
-            IncludeRegistry<AuthorizationRegistry>();
             For<IAuthorizationHandler>().Add<AuthorizationHandler>();
             For<IFeatureTogglesService>().Use<FeatureTogglesService>().Singleton();
         }

--- a/src/SFA.DAS.Authorization.EmployerFeatures/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.Authorization.EmployerFeatures/ServiceCollectionExtensions.cs
@@ -4,9 +4,9 @@ namespace SFA.DAS.Authorization.EmployerFeatures
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddEmployerFeaturesAuthorization(this IServiceCollection services)
+        public static IServiceCollection AddEmployerFeaturesAuthorization<T>(this IServiceCollection services) where T : class, IAuthorizationContextProvider
         {
-            return services.AddAuthorization()
+            return services.AddAuthorization<T>()
                 .AddScoped<IAuthorizationHandler, AuthorizationHandler>()
                 .AddSingleton<IFeatureTogglesService, FeatureTogglesService>();
         }

--- a/src/SFA.DAS.Authorization.EmployerFeatures/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.Authorization.EmployerFeatures/ServiceCollectionExtensions.cs
@@ -4,10 +4,9 @@ namespace SFA.DAS.Authorization.EmployerFeatures
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddEmployerFeaturesAuthorization<T>(this IServiceCollection services) where T : class, IAuthorizationContextProvider
+        public static IServiceCollection AddEmployerFeaturesAuthorization(this IServiceCollection services)
         {
-            return services.AddAuthorization<T>()
-                .AddScoped<IAuthorizationHandler, AuthorizationHandler>()
+            return services.AddScoped<IAuthorizationHandler, AuthorizationHandler>()
                 .AddSingleton<IFeatureTogglesService, FeatureTogglesService>();
         }
     }

--- a/src/SFA.DAS.Authorization.EmployerUserRoles/EmployerUserRolesAuthorizationRegistry.cs
+++ b/src/SFA.DAS.Authorization.EmployerUserRoles/EmployerUserRolesAuthorizationRegistry.cs
@@ -7,7 +7,6 @@ namespace SFA.DAS.Authorization.EmployerUserRoles
     {
         public EmployerUserRolesAuthorizationRegistry()
         {
-            IncludeRegistry<AuthorizationRegistry>();
             IncludeRegistry<EmployerAccountsApiClientRegistry>();
             For<IAuthorizationHandler>().Add<AuthorizationHandler>();
         }

--- a/src/SFA.DAS.Authorization.NetCoreTestHarness/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.Authorization.NetCoreTestHarness/DependencyResolution/IoC.cs
@@ -11,6 +11,7 @@ namespace SFA.DAS.Authorization.NetCoreTestHarness.DependencyResolution
         public static void Initialize(Registry registry)
         {
             registry.IncludeRegistry<AutoConfigurationRegistry>();
+            registry.IncludeRegistry<EmployerFeaturesAuthorizationRegistry>();
             registry.IncludeRegistry<EmployerUserRolesAuthorizationRegistry>();
             registry.IncludeRegistry<ProviderPermissionsAuthorizationRegistry>();
             registry.IncludeRegistry<TestAuthorizationRegistry>();

--- a/src/SFA.DAS.Authorization.NetCoreTestHarness/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.Authorization.NetCoreTestHarness/DependencyResolution/IoC.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Authorization.NetCoreTestHarness.DependencyResolution
     {
         public static void Initialize(Registry registry)
         {
+            registry.IncludeRegistry<AuthorizationRegistry>();
             registry.IncludeRegistry<AutoConfigurationRegistry>();
             registry.IncludeRegistry<EmployerFeaturesAuthorizationRegistry>();
             registry.IncludeRegistry<EmployerUserRolesAuthorizationRegistry>();

--- a/src/SFA.DAS.Authorization.NetCoreTestHarness/Startup/AspNetStartup.cs
+++ b/src/SFA.DAS.Authorization.NetCoreTestHarness/Startup/AspNetStartup.cs
@@ -17,8 +17,6 @@ namespace SFA.DAS.Authorization.NetCoreTestHarness.Startup
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie(o => o.LoginPath = new PathString("/account/http401"));
 
-            services.AddEmployerFeaturesAuthorization();
-
             services.AddMvc(o => o.AddAuthorization())
                 .AddControllersAsServices()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/src/SFA.DAS.Authorization.NetFrameworkTestHarness/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.Authorization.NetFrameworkTestHarness/DependencyResolution/IoC.cs
@@ -13,15 +13,15 @@ namespace SFA.DAS.Authorization.NetFrameworkTestHarness.DependencyResolution
         public static IContainer Initialize()
         {
             return new Container(c =>
-                {
-                    c.AddRegistry<AutoConfigurationRegistry>();
-                    c.AddRegistry<EmployerFeaturesAuthorizationRegistry>();
-                    c.AddRegistry<EmployerUserRolesAuthorizationRegistry>();
-                    c.AddRegistry<ProviderPermissionsAuthorizationRegistry>();
-                    c.AddRegistry<TestAuthorizationRegistry>();
-                    c.AddRegistry<DefaultRegistry>();
-                }
-            );
+            {
+                c.AddRegistry<AuthorizationRegistry>();
+                c.AddRegistry<AutoConfigurationRegistry>();
+                c.AddRegistry<EmployerFeaturesAuthorizationRegistry>();
+                c.AddRegistry<EmployerUserRolesAuthorizationRegistry>();
+                c.AddRegistry<ProviderPermissionsAuthorizationRegistry>();
+                c.AddRegistry<TestAuthorizationRegistry>();
+                c.AddRegistry<DefaultRegistry>();
+            });
         }
     }
 }

--- a/src/SFA.DAS.Authorization.ProviderPermissions/ProviderPermissionsAuthorizationRegistry.cs
+++ b/src/SFA.DAS.Authorization.ProviderPermissions/ProviderPermissionsAuthorizationRegistry.cs
@@ -7,7 +7,6 @@ namespace SFA.DAS.Authorization.ProviderPermissions
     {
         public ProviderPermissionsAuthorizationRegistry()
         {
-            IncludeRegistry<AuthorizationRegistry>();
             IncludeRegistry<ProviderRelationshipsApiClientRegistry>();
             For<IAuthorizationHandler>().Add<AuthorizationHandler>();
         }

--- a/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextCacheTests.cs
+++ b/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextCacheTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Testing;
+
+namespace SFA.DAS.Authorization.UnitTests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class AuthorizationContextCacheTests : FluentTest<AuthorizationContextCacheTestsFixture>
+    {
+        [Test]
+        public void GetAuthorizationContext_WhenGettingAuthorizationContext_ThenShouldReturnAuthorizationContext()
+        {
+            Test(f => f.GetAuthorizationContext(), (f, r) => r.Should().NotBeNull());
+        }
+
+        [Test]
+        public void GetAuthorizationContext_WhenGettingAuthorizationContext_ThenShouldGetAuthorizationContextFromAuthorizationContextProvider()
+        {
+            Test(f => f.GetAuthorizationContext(), f => f.AuthorizationContextProvider.Verify(p => p.GetAuthorizationContext(), Times.Once));
+        }
+
+        [Test]
+        public void GetAuthorizationContext_WhenGettingAuthorizationContextMultipleTimes_ThenShouldGetAuthorizationContextFromAuthorizationContextProviderOnce()
+        {
+            Test(f => f.GetAuthorizationContext(), f => f.AuthorizationContextProvider.Verify(p => p.GetAuthorizationContext(), Times.Once));
+        }
+
+        [Test]
+        public void GetAuthorizationContext_WhenGettingAuthorizationContextMultipleTimes_ThenShouldReturnSameAuthorizationContext()
+        {
+            Test(f => f.GetAuthorizationContext(3), (f, r) => f.AuthorizationContexts.ForEach(c => c.Should().Be(r)));
+        }
+    }
+
+    public class AuthorizationContextCacheTestsFixture
+    {
+        public Mock<IAuthorizationContextProvider> AuthorizationContextProvider { get; set; }
+        public IAuthorizationContextProvider AuthorizationContextCache { get; set; }
+        public List<IAuthorizationContext> AuthorizationContexts { get; set; }
+
+        public AuthorizationContextCacheTestsFixture()
+        {
+            AuthorizationContextProvider = new Mock<IAuthorizationContextProvider>();
+            AuthorizationContextCache = new AuthorizationContextCache(AuthorizationContextProvider.Object);
+            AuthorizationContexts = new List<IAuthorizationContext>();
+
+            AuthorizationContextProvider.Setup(p => p.GetAuthorizationContext()).Returns(() => new AuthorizationContext());
+        }
+
+        public IAuthorizationContext GetAuthorizationContext(int? count = 1)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                AuthorizationContexts.Add(AuthorizationContextCache.GetAuthorizationContext());
+            }
+
+            return AuthorizationContexts.First();
+        }
+    }
+}

--- a/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextCacheTests.cs
+++ b/src/SFA.DAS.Authorization.UnitTests/AuthorizationContextCacheTests.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void GetAuthorizationContext_WhenGettingAuthorizationContext_ThenShouldReturnAuthorizationContext()
         {
-            Test(f => f.GetAuthorizationContext(), (f, r) => r.Should().NotBeNull());
+            Test(f => f.GetAuthorizationContext(), (f, r) => r.SingleOrDefault().Should().NotBeNull());
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace SFA.DAS.Authorization.UnitTests
         [Test]
         public void GetAuthorizationContext_WhenGettingAuthorizationContextMultipleTimes_ThenShouldReturnSameAuthorizationContext()
         {
-            Test(f => f.GetAuthorizationContext(3), (f, r) => f.AuthorizationContexts.ForEach(c => c.Should().Be(r)));
+            Test(f => f.GetAuthorizationContext(3), (f, r) => r.ForEach(c => c.Should().Be(r.First())));
         }
     }
 
@@ -40,25 +40,25 @@ namespace SFA.DAS.Authorization.UnitTests
     {
         public Mock<IAuthorizationContextProvider> AuthorizationContextProvider { get; set; }
         public IAuthorizationContextProvider AuthorizationContextCache { get; set; }
-        public List<IAuthorizationContext> AuthorizationContexts { get; set; }
 
         public AuthorizationContextCacheTestsFixture()
         {
             AuthorizationContextProvider = new Mock<IAuthorizationContextProvider>();
             AuthorizationContextCache = new AuthorizationContextCache(AuthorizationContextProvider.Object);
-            AuthorizationContexts = new List<IAuthorizationContext>();
 
             AuthorizationContextProvider.Setup(p => p.GetAuthorizationContext()).Returns(() => new AuthorizationContext());
         }
 
-        public IAuthorizationContext GetAuthorizationContext(int? count = 1)
+        public List<IAuthorizationContext> GetAuthorizationContext(int count = 1)
         {
+            var authorizationContexts = new List<IAuthorizationContext>();
+            
             for (var i = 0; i < count; i++)
             {
-                AuthorizationContexts.Add(AuthorizationContextCache.GetAuthorizationContext());
+                authorizationContexts.Add(AuthorizationContextCache.GetAuthorizationContext());
             }
 
-            return AuthorizationContexts.First();
+            return authorizationContexts;
         }
     }
 }

--- a/src/SFA.DAS.Authorization/AuthorizationContextCache.cs
+++ b/src/SFA.DAS.Authorization/AuthorizationContextCache.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace SFA.DAS.Authorization
+{
+    public class AuthorizationContextCache : IAuthorizationContextProvider
+    {
+        private readonly Lazy<IAuthorizationContext> _authorizationContext;
+
+        public AuthorizationContextCache(IAuthorizationContextProvider authorizationContextProvider)
+        {
+            _authorizationContext = new Lazy<IAuthorizationContext>(authorizationContextProvider.GetAuthorizationContext);
+        }
+
+        public IAuthorizationContext GetAuthorizationContext()
+        {
+            return _authorizationContext.Value;
+        }
+    }
+}

--- a/src/SFA.DAS.Authorization/AuthorizationRegistry.cs
+++ b/src/SFA.DAS.Authorization/AuthorizationRegistry.cs
@@ -8,6 +8,7 @@ namespace SFA.DAS.Authorization
         public AuthorizationRegistry()
         {
             For<IAuthorizationContext>().Use<AuthorizationContext>();
+            For<IAuthorizationContextProvider>().DecorateAllWith<AuthorizationContextCache>();
             For<IAuthorizationService>().Use<AuthorizationService>();
             For<ILogger>().Use(c => c.GetInstance<ILoggerFactoryManager>().GetLoggerFactory().CreateLogger(c.ParentType));
             For<ILoggerFactoryManager>().Use(c => new LoggerFactoryManager(c.TryGetInstance<ILoggerFactory>())).Singleton();

--- a/src/SFA.DAS.Authorization/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.Authorization/ServiceCollectionExtensions.cs
@@ -4,10 +4,12 @@ namespace SFA.DAS.Authorization
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddAuthorization(this IServiceCollection services)
+        public static IServiceCollection AddAuthorization<T>(this IServiceCollection services) where T : class, IAuthorizationContextProvider
         {
             return services.AddScoped<IAuthorizationContext, AuthorizationContext>()
-                .AddScoped<IAuthorizationService, AuthorizationService>();
+                .AddScoped<IAuthorizationContextProvider>(p => new AuthorizationContextCache(p.GetService<T>()))
+                .AddScoped<IAuthorizationService, AuthorizationService>()
+                .AddScoped<T>();
         }
     }
 }


### PR DESCRIPTION
Added `AuthorizationContextCache` as an `IAuthorizationContextProvider` adapter to ensure `GetAuthorizationContext` is only called once per scope.