### PR TITLE
MF-310 - Add option to allow empty cohort

### DIFF
--- a/src/SFA.DAS.Authorization.CommitmentPermissions/Models/Operation.cs
+++ b/src/SFA.DAS.Authorization.CommitmentPermissions/Models/Operation.cs
@@ -2,6 +2,7 @@ namespace SFA.DAS.Authorization.CommitmentPermissions.Models
 {
     public enum Operation
     {
-        AccessCohort
+        AccessCohort,
+        IgnoreEmptyCohort
     }
 }

--- a/src/SFA.DAS.Authorization.CommitmentPermissions/Options/CommitmentOperation.cs
+++ b/src/SFA.DAS.Authorization.CommitmentPermissions/Options/CommitmentOperation.cs
@@ -4,7 +4,10 @@ namespace SFA.DAS.Authorization.CommitmentPermissions.Options
     {
         internal const string Prefix = "CommitmentOperation.";
         internal const string AccessCohortOption = "AccessCohort";
+        internal const string IgnoreEmptyCohortOption = "IgnoreEmptyCohort";
         
         public const string AccessCohort = Prefix + AccessCohortOption;
+
+        public const string AllowEmptyCohort = Prefix + IgnoreEmptyCohortOption;
     }
 }


### PR DESCRIPTION
Removed the Ensure no or and no and options. Added a new option to allow
empty cohorts. If there is an empty cohort and the option is present it
is returned as authenticated