### PR TITLE
CV-398-Fix toggle bug which is caused when no features exists (this occurs f…

### DIFF
--- a/src/SFA.DAS.Authorization.Features.UnitTests/Services/FeatureTogglesServiceTests.cs
+++ b/src/SFA.DAS.Authorization.Features.UnitTests/Services/FeatureTogglesServiceTests.cs
@@ -19,6 +19,12 @@ namespace SFA.DAS.Authorization.Features.UnitTests.Services
         }
         
         [Test]
+        public void GetFeatureToggle_WhenFeatureConfigurationIsNull_ThenShouldReturnDisabledFeatureToggle()
+        {
+            Test(f => f.SetFeatureConfigurationToNull().GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.Match<FeatureToggle>(t => t.Feature == f.Feature && t.IsEnabled == false));
+        }
+
+        [Test]
         public void GetFeatureToggle_WhenFeatureToggleDoesNotExistForFeature_ThenShouldReturnDisabledFeatureToggle()
         {
             Test(f => f.GetFeatureToggle(), (f, r) => r.Should().NotBeNull().And.Match<FeatureToggle>(t => t.Feature == f.Feature && t.IsEnabled == false));
@@ -45,6 +51,12 @@ namespace SFA.DAS.Authorization.Features.UnitTests.Services
             FeatureToggleService = new FeatureTogglesService<FeaturesConfiguration, FeatureToggle>(FeaturesConfiguration);
             
             return FeatureToggleService.GetFeatureToggle(Feature);
+        }
+
+        public FeatureTogglesServiceTestsFixture SetFeatureConfigurationToNull()
+        {
+            FeaturesConfiguration = null;
+            return this;
         }
 
         public FeatureTogglesServiceTestsFixture SetFeatureToggle()

--- a/src/SFA.DAS.Authorization.Features/Services/FeatureTogglesService.cs
+++ b/src/SFA.DAS.Authorization.Features/Services/FeatureTogglesService.cs
@@ -13,7 +13,14 @@ namespace SFA.DAS.Authorization.Features.Services
 
         public FeatureTogglesService(TConfiguration configuration)
         {
-            _featureToggles = new ConcurrentDictionary<string, TFeatureToggle>(configuration.FeatureToggles.ToDictionary(t => t.Feature));
+            if (configuration?.FeatureToggles == null)
+            {
+                _featureToggles = new ConcurrentDictionary<string, TFeatureToggle>();
+            }
+            else
+            {
+                _featureToggles = new ConcurrentDictionary<string, TFeatureToggle>(configuration.FeatureToggles.ToDictionary(t => t.Feature));
+            }
         }
 
         public TFeatureToggle GetFeatureToggle(string feature)


### PR DESCRIPTION
…or an empty array or a null object)